### PR TITLE
[XJ] Add prevention logics of livelock or starvation on ring router.

### DIFF
--- a/src/main/scala/xijiang/Ring.scala
+++ b/src/main/scala/xijiang/Ring.scala
@@ -35,6 +35,8 @@ class Ring(local: Boolean)(implicit p: Parameters) extends ZJModule {
   override val desiredName = ringName
   val io = if(!tfs) Some(IO(new RingIO(local))) else None
   val tfsio = if(tfs) Some(IO(new TfsIO(local))) else None
+  io.foreach(dontTouch(_))
+  tfsio.foreach(dontTouch(_))
 
   private val ring = if(local) p(ZJParametersKey).localRing else p(ZJParametersKey).csnRing
   private val routersAndNodes = ring.map(n => (n.genRouter(p), n))

--- a/src/main/scala/xijiang/router/base/ChannelTap.scala
+++ b/src/main/scala/xijiang/router/base/ChannelTap.scala
@@ -3,18 +3,18 @@ package xijiang.router.base
 import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
-import zhujiang.ZJModule
+import zhujiang.{ZJModule, ZJParametersKey}
 import zhujiang.chi.Flit
 
 class SingleChannelTap[T <: Flit](gen: T, channel: String, c2c: Boolean)(implicit p: Parameters) extends ZJModule {
   private val fw = gen.getWidth
+  private val timerBits = p(ZJParametersKey).injectRsvdTimerShift
   val io = IO(new Bundle {
-    val in = Input(Valid(new ChannelPayload(gen)))
-    val out = Output(Valid(new ChannelPayload(gen)))
+    val in = Input(new ChannelBundle(gen))
+    val out = Output(new ChannelBundle(gen))
     val inject = Flipped(Decoupled(UInt(fw.W)))
-    val eject = Decoupled(new ChannelPayload(gen))
+    val eject = Decoupled(UInt(fw.W))
     val nid = Input(UInt(niw.W))
-    val liveCntInit = Input(UInt(maxRingSize.W))
   })
   private val modName = if(c2c) {
     s"C2cSingleChannelTap$channel"
@@ -22,86 +22,103 @@ class SingleChannelTap[T <: Flit](gen: T, channel: String, c2c: Boolean)(implici
     s"SingleChannelTap$channel"
   }
   override val desiredName = modName
+  private val normalShift = 0
+  private val injectRsvdShift = 1
+  private val waitSlotShift = 2
 
-  private val actualIn = Wire(Valid(new ChannelPayload(gen)))
-  private val selIn = io.in.valid && !io.eject.fire
-  actualIn.valid := selIn || io.inject.valid
+  private val s_normal = (1 << normalShift).U(3.W)
+  private val s_inject_reserved = (1 << injectRsvdShift).U(3.W)
+  private val s_wait_slot = (1 << waitSlotShift).U(3.W)
+  private val state = RegInit(s_normal)
+  private val counter = RegInit(0.U(timerBits.W))
+  private val flitNext = Wire(Valid(UInt(fw.W)))
+  private val rsvdNext = Wire(Valid(UInt(niw.W)))
+  private val injectFire = io.inject.fire
+  private val ejectFire = io.eject.fire
+  private val meetRsvdSlot = io.in.rsvd.bits === io.nid
+
+  when(injectFire) {
+    counter := 0.U
+  }.elsewhen(io.inject.valid && !io.inject.ready && state(normalShift) && !counter(timerBits - 1)) {
+    counter := counter + 1.U
+  }
+
+  switch(state) {
+    is(s_normal) {
+      state := Mux(counter(timerBits - 1), s_inject_reserved, s_normal)
+    }
+    is(s_inject_reserved) {
+      state := Mux(injectFire, s_normal, Mux(io.in.rsvd.valid, s_inject_reserved, s_wait_slot))
+    }
+    is(s_wait_slot) {
+      state := Mux(injectFire, s_normal, s_wait_slot)
+    }
+  }
+  when(io.in.rsvd.valid && meetRsvdSlot) {
+    assert(state(waitSlotShift), "Unexpected reserved slot!")
+  }
+
+  private val emptySlot = Mux(io.in.flit.valid, ejectFire, true.B)
+  private val availableSlot = Mux(io.in.rsvd.valid, meetRsvdSlot, !state(waitSlotShift))
+  dontTouch(emptySlot)
+  dontTouch(availableSlot)
+  io.inject.ready := emptySlot && availableSlot
+
   private val injectFlit = WireInit(io.inject.bits.asTypeOf(gen))
   if(!c2c) injectFlit.src := io.nid
+  flitNext.valid := injectFire || io.in.flit.valid && !ejectFire
+  flitNext.bits := Mux(injectFire, injectFlit.asUInt, io.in.flit.bits)
 
-  when(selIn) {
-    actualIn.bits.liveCnt := Mux(io.in.bits.liveCnt.orR, io.in.bits.liveCnt - 1.U, 0.U)
-  }.otherwise {
-    actualIn.bits.liveCnt := io.liveCntInit
-  }
-  actualIn.bits.flit := Mux(selIn, io.in.bits.flit, injectFlit.asUInt)
-  io.inject.ready := !selIn
+  rsvdNext.valid := (state(injectRsvdShift) || io.in.rsvd.valid) && !injectFire
+  rsvdNext.bits := Mux(state(injectRsvdShift) && !io.in.rsvd.valid, io.nid, io.in.rsvd.bits)
 
-  io.out := Pipe(actualIn)
+  io.out.flit := Pipe(flitNext)
+  io.out.rsvd := Pipe(rsvdNext)
 
   if(c2c) {
-    io.eject.valid := Flit.getTgt(io.in.bits.flit)(p)(nodeNidBits - 1, 0) === io.nid(nodeNidBits - 1, 0) && io.in.valid
+    io.eject.valid := Flit.getTgt(io.in.flit.bits)(p)(nodeNidBits - 1, 0) === io.nid(nodeNidBits - 1, 0) && io.in.flit.valid
   } else {
-    io.eject.valid := Flit.getTgt(io.in.bits.flit)(p) === io.nid && io.in.valid
+    io.eject.valid := Flit.getTgt(io.in.flit.bits)(p) === io.nid && io.in.flit.valid
   }
-  io.eject.bits := io.in.bits
+  io.eject.bits := io.in.flit.bits
 }
 
 class ChannelTap[T <: Flit](
-  val gen: T, channel: String, tgtSeq: Seq[Seq[Int]],
-  escape: Boolean = false, ejectBuf: Int = 0, c2c: Boolean = false
+  val gen: T, channel: String, ringNum: Int,
+  ejectBuf: Int = 0, c2c: Boolean = false
 )(implicit p: Parameters) extends ZJModule {
   private val fw = gen.getWidth
   val io = IO(new Bundle {
-    val rx = Input(Vec(tgtSeq.size, Valid(new ChannelPayload(gen))))
-    val tx = Output(Vec(tgtSeq.size, Valid(new ChannelPayload(gen))))
+    val rx = Input(Vec(ringNum, new ChannelBundle(gen)))
+    val tx = Output(Vec(ringNum, new ChannelBundle(gen)))
     val inject = Flipped(Decoupled(UInt(fw.W)))
     val eject = Decoupled(UInt(fw.W))
     val nid = Input(UInt(niw.W))
-    val liveCntInit = Input(UInt(maxRingSize.W))
+    val injectTapSelOH = Input(Vec(ringNum, Bool()))
   })
+  override val desiredName = if(c2c) s"C2cChannelTap$channel" else s"ChannelTap$channel"
 
-  private val tgt = Flit.getTgt(io.inject.bits)(p)
-  private val injectTapSelOH = if(tgtSeq.size > 1) tgtSeq.map(_.map(_.U === tgt).reduce(_ || _)) else Seq(true.B)
   when(io.inject.valid) {
-    assert(PopCount(injectTapSelOH) === 1.U, "Only one side can be picked!")
+    assert(PopCount(io.injectTapSelOH) === 1.U, "Only one side can be picked!")
   }
 
-  private val taps = Seq.fill(tgtSeq.size)(Module(new SingleChannelTap(gen, channel, c2c)))
-  private val ejectArb = Module(new RRArbiter(new ChannelPayload(gen), tgtSeq.size))
+  private val taps = Seq.fill(ringNum)(Module(new SingleChannelTap(gen, channel, c2c)))
+  private val ejectArb = Module(new RRArbiter(UInt(gen.getWidth.W), ringNum))
   for(idx <- taps.indices) {
     taps(idx).io.in := io.rx(idx)
     io.tx(idx) := taps(idx).io.out
-    taps(idx).io.inject.valid := io.inject.valid && injectTapSelOH(idx)
+    taps(idx).io.inject.valid := io.inject.valid && io.injectTapSelOH(idx)
     taps(idx).io.inject.bits := io.inject.bits
     taps(idx).io.nid := io.nid
-    taps(idx).io.liveCntInit := io.liveCntInit
     ejectArb.io.in(idx) <> taps(idx).io.eject
   }
-  io.inject.ready := Mux1H(injectTapSelOH, taps.map(_.io.inject.ready))
+  io.inject.ready := Mux1H(io.injectTapSelOH, taps.map(_.io.inject.ready))
 
-  private val tryToEject = Wire(Decoupled(UInt(fw.W)))
-  private val ejectBuffer = if(ejectBuf > 0) Some(Module(new Queue(UInt(fw.W), ejectBuf, pipe = true))) else None
-  if(ejectBuf > 2) {
+  private val ejectBuffer = if(ejectBuf > 0) Some(Module(new EjectBuffer(gen, ejectBuf, channel))) else None
+  if(ejectBuf > 0) {
     io.eject <> ejectBuffer.get.io.deq
-    ejectBuffer.get.io.enq <> tryToEject
+    ejectBuffer.get.io.enq <> ejectArb.io.out
   } else {
-    io.eject <> tryToEject
-  }
-
-  private val escapeBuffer = if(escape) Some(Module(new Queue(UInt(fw.W), 2))) else None
-  if(escape) {
-    val ebuf = escapeBuffer.get
-    val tryEscEnq = ejectArb.io.out.bits.liveCnt === 0.U && (!tryToEject.ready || ebuf.io.deq.valid)
-    ebuf.io.enq.valid := ejectArb.io.out.valid && tryEscEnq
-    ebuf.io.enq.bits := ejectArb.io.out.bits.flit
-    ejectArb.io.out.ready := Mux(tryEscEnq, ebuf.io.enq.ready, tryToEject.ready)
-    tryToEject.bits := Mux(ebuf.io.deq.valid, ebuf.io.deq.bits, ejectArb.io.out.bits.flit)
-    tryToEject.valid := ebuf.io.deq.valid || ejectArb.io.out.valid
-    ebuf.io.deq.ready := tryToEject.ready
-  } else {
-    tryToEject.valid := ejectArb.io.out.valid
-    tryToEject.bits := ejectArb.io.out.bits.flit
-    ejectArb.io.out.ready := tryToEject.ready
+    io.eject <> ejectArb.io.out
   }
 }

--- a/src/main/scala/xijiang/router/base/EjectBuffer.scala
+++ b/src/main/scala/xijiang/router/base/EjectBuffer.scala
@@ -1,0 +1,66 @@
+package xijiang.router.base
+
+import chisel3._
+import chisel3.util._
+import org.chipsalliance.cde.config.Parameters
+import xs.utils.PickOneLow
+import zhujiang.ZJModule
+import zhujiang.chi.Flit
+
+class EjectBuffer[T <: Flit](gen: T, size: Int, chn: String)(implicit p: Parameters) extends ZJModule {
+  private val tagBits = 12 + 2 * niw // TgtId + SrcId + TxnId
+  val io = IO(new Bundle {
+    val enq = Flipped(Decoupled(UInt(gen.getWidth.W)))
+    val deq = Decoupled(UInt(gen.getWidth.W))
+  })
+  override val desiredName = s"EjectBuffer$chn"
+  private val queue = Module(new Queue(UInt(gen.getWidth.W), size, pipe = true))
+  private val rsvdTags = Reg(Vec(size, UInt(tagBits.W)))
+  private val rsvdValids = RegInit(VecInit(Seq.fill(size)(false.B)))
+  private val empties = RegInit(size.U(log2Ceil(size + 1).W))
+  private val rsvdNumReg = RegInit(0.U(log2Ceil(size + 1).W))
+
+  when(queue.io.enq.fire && !queue.io.deq.fire) {
+    assert(empties > 0.U)
+    empties := empties - 1.U
+  }.elsewhen(!queue.io.enq.fire && queue.io.deq.fire) {
+    assert(empties < size.U)
+    empties := empties + 1.U
+  }
+  when(empties.orR) {
+    assert(queue.io.enq.ready)
+  }
+
+  private def getTag(flit: UInt): UInt = flit(tagBits + 3, 4)
+
+  io.deq <> queue.io.deq
+  private val rsvdSel = PickOneLow(rsvdValids)
+  private val rsvdHit = Cat(rsvdTags.zip(rsvdValids).map(e => e._1 === getTag(io.enq.bits) && e._2)).orR
+  private val doReserve = io.enq.valid && !io.enq.ready && !rsvdHit && rsvdSel.valid
+
+  when(rsvdHit && queue.io.enq.fire) {
+    rsvdNumReg := rsvdNumReg - 1.U
+  }.elsewhen(doReserve) {
+    rsvdNumReg := rsvdNumReg + 1.U
+  }
+  assert(rsvdNumReg === PopCount(rsvdValids))
+
+  for(idx <- rsvdValids.indices) {
+    val v = rsvdValids(idx)
+    val tag = rsvdTags(idx)
+    val doRsv = rsvdSel.bits(idx) && doReserve
+    when(v && queue.io.enq.fire && getTag(io.enq.bits) === tag) {
+      v := false.B
+    }.elsewhen(doRsv) {
+      v := true.B
+    }
+    when(doRsv) {
+      tag := getTag(io.enq.bits)
+    }
+  }
+
+  private val allowEnq = Mux(rsvdHit, true.B, rsvdNumReg < empties)
+  queue.io.enq.valid := io.enq.valid & allowEnq
+  queue.io.enq.bits := io.enq.bits
+  io.enq.ready := queue.io.enq.ready & allowEnq
+}

--- a/src/main/scala/xijiang/tfb/TrafficBoardFileManager.scala
+++ b/src/main/scala/xijiang/tfb/TrafficBoardFileManager.scala
@@ -273,7 +273,7 @@ object TrafficBoardFileManager {
        |      for(auto &d: v1) {
        |        d->timer++;
        |        if(d->timer > TIME_OUT) {
-       |          TFB_ERR("node 0x%x chn %d inject time %lx time out!\\n", k0, k1, d->inject_time);
+       |          TFB_ERR("node 0x%x chn %d inject time %lu time out!\\n", k0, k1, d->inject_time);
        |          time_out = true;
        |        }
        |      }

--- a/src/main/scala/zhujiang/ZJParameters.scala
+++ b/src/main/scala/zhujiang/ZJParameters.scala
@@ -23,13 +23,14 @@ case class ZJParameters(
   Y: Int = 0,
   DC: Boolean = false,
   P: Boolean = false,
-  snoopEjectBufDepth: Int = 4,
-  reqEjectBufDepth: Int = 4,
+  snoopEjectBufDepth: Int = 8,
+  reqEjectBufDepth: Int = 8,
   localNodeParams: Seq[NodeParam] = Seq(),
   csnNodeParams: Seq[NodeParam] = Seq(),
   c2cParams: C2cParams = C2cParams(),
   tfbParams: Option[TrafficBoardParams] = Some(TrafficBoardParams()),
-  tfsParams: Option[TrafficSimParams] = None
+  tfsParams: Option[TrafficSimParams] = None,
+  injectRsvdTimerShift: Int = 8
 ) {
   val requestAddrBits = 48
   val snoopAddrBits = requestAddrBits - 3
@@ -54,8 +55,8 @@ case class ZJParameters(
   val maxFlitBits = Seq(reqFlitBits, respFlitBits, snoopFlitBits, dataFlitBits).max
   require(nodeIdBits >= 7 && nodeIdBits <= 11)
 
-  val localRing: Seq[Node] = if(localNodeParams.nonEmpty) getRing(localNodeParams, false) else Seq()
-  val csnRing: Seq[Node] = if(csnNodeParams.nonEmpty) getRing(csnNodeParams, true) else Seq()
+  lazy val localRing: Seq[Node] = if(localNodeParams.nonEmpty) getRing(localNodeParams, false) else Seq()
+  lazy val csnRing: Seq[Node] = if(csnNodeParams.nonEmpty) getRing(csnNodeParams, true) else Seq()
 
   private def getRing(nodeParams: Seq[NodeParam], csn: Boolean): Seq[Node] = {
     require(nodeParams.size >= 3)
@@ -72,8 +73,8 @@ case class ZJParameters(
         case NodeType.HF => n.nid = hfId; hfId = hfId + 1
         case NodeType.HI => n.nid = hiId; hiId = hiId + 1
         case NodeType.C => n.nid = cId; cId = cId + 1
-        case NodeType.P => n.nid = pId; pId = pId + 1
         case NodeType.S => n.nid = sId; sId = sId + 1
+        case NodeType.P => n.nid = pId; pId = pId + 1
       }
       n
     }
@@ -101,9 +102,6 @@ trait HasZJParams {
   val dw = p(ZJParametersKey).dataBits
   val bew = p(ZJParametersKey).beBits
   val chipAddrBits = p(ZJParametersKey).chipAddrBits
-  val localRingSize = p(ZJParametersKey).localRing.size
-  val csnRingSize = p(ZJParametersKey).csnRing.size
-  val maxRingSize = localRingSize.max(csnRingSize)
   val reqFlitBits = p(ZJParametersKey).reqFlitBits
   val respFlitBits = p(ZJParametersKey).respFlitBits
   val snoopFlitBits = p(ZJParametersKey).snoopFlitBits

--- a/src/main/scala/zhujiang/chi/Flit.scala
+++ b/src/main/scala/zhujiang/chi/Flit.scala
@@ -160,7 +160,7 @@ object ChannelEncodings {
     "RSP" -> RSP,
     "DAT" -> DAT,
     "SNP" -> SNP,
-    "ERQ" -> SNP
+    "ERQ" -> ERQ
   )
 }
 

--- a/src/test/scala/xijiang/TrafficSimTop.scala
+++ b/src/test/scala/xijiang/TrafficSimTop.scala
@@ -17,11 +17,12 @@ class TfsTopConfig extends Config((site, here, up) => {
       NodeParam(nodeType = NodeType.R),
       NodeParam(nodeType = NodeType.R),
       NodeParam(nodeType = NodeType.HF),
-      NodeParam(nodeType = NodeType.P),
+      NodeParam(nodeType = NodeType.S),
       NodeParam(nodeType = NodeType.R),
       NodeParam(nodeType = NodeType.R),
       NodeParam(nodeType = NodeType.HF),
       NodeParam(nodeType = NodeType.HI),
+      NodeParam(nodeType = NodeType.S),
     ),
     csnNodeParams = Seq(
       NodeParam(nodeType = NodeType.R),


### PR DESCRIPTION
1. Flit injector will mark a slot as a reserved slot when an injecting flit waiting for too long. No other flit can inject a flit to a reserved slot even when it is empty. Only the slot marker can inject its flit on the slot. After a flit is injected, the reserving mark will be removed.
2. If eject buffer is full but the ring tap try to eject a flit, eject buffer will record the tag of the flit and reserve a slot in eject buffer. No flit can occupy the reserved entry, unless it has been recorded by the eject buffer. Once a flit enqueue the eject buffer, the corresponding record will be removed.